### PR TITLE
Minor Frontend Improvements

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -162,6 +162,7 @@ owt-v86-browser, owt-bas-browser {
 owt-bas-browser canvas {
   margin-top: 1em;
   cursor: none;
+  border-radius: 0.5rem;
 }
 
 owt-v86-browser {

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -10,9 +10,10 @@ html, body {
 }
 
 .owt-title {
+  font-size: 1.4rem;
   font-family: cursive;
   font-variant-caps: petite-caps;
-  word-break: break-word;
+  word-break: none;
   margin-top: 0.25em;
   margin-bottom: 0px;
   text-align: center;
@@ -182,4 +183,3 @@ owt-native {
   height: 100%;
   border: 0px;
 }
-

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -142,8 +142,7 @@ a:visited {
   max-width: 150px;
 }
 
-.by-wr {
-  margin-top: 1.0rem;
+.sidebar-centered-text-container {
   font-size: 0.75em;
   text-align: center;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -354,14 +354,22 @@ class OldWebToday extends LitElement
                 <input @change="${this.onChangeTs}" class="form-input" type="text" id="dt" ?disabled="${!this.replayTs}"
                   .value="${this.tsToDateMin(this.inputTs)}" placeholder="YYYY-MM-DD hh:mm:ss"></input>
 
+                ${!!this.replayTs ? html`
+                <details>
+                  <summary>Web Archive Sources</summary>
+                  <div>
+                  <label class="form-checkbox">
+                    <input type="checkbox" disabled checked>
+                    <i class="form-icon"></i>Internet Archive
+                    <p style="font-size: 0.75em">More options coming soon...</p>
+                  </label>
+                  </div>
+                </details>` : ``}
+
                 ${this.showTsUpdateMessage ? html`
                   <div class="msg" style="background-color: aliceblue">
                     Date Updated!<br/>Click the <i>Refresh</i> button or load a new page in the emulated browser to start browsing at the new date.
                   </div>` : html``}
-
-                  <div class="sidebar-centered-text-container">
-                    <p>Archived Webpages served from Internet Archive</p>
-                  </div>
 
                 ${this.isRunning ? html`
                   <div style="margin: 1em 0">

--- a/src/main.js
+++ b/src/main.js
@@ -392,12 +392,17 @@ class OldWebToday extends LitElement
                 <button @click="${this.onDL}">Save State</button>` : ''}
               </div>
             </div>
-            <div class="sidebar-centered-text-container" style="margin-top: 2rem;">
-              <p>
-                <a href="https://github.com/oldweb-today/oldweb-today" target="_blank">OldWeb.Today on GitHub</a>
-                <br>
-                <br>
-                <a href="https://opencollective.com/webrecorder" target="_blank">Support Webrecorder on OpenCollective ❤️</a>
+            <div class="sidebar-centered-text-container" style="margin-top: 1.2rem">
+              <div style="font-size: 1.1em; padding: 0.5rem; border-radius: 4px; background-color: #eee">
+                <p style="margin-bottom: 0.35rem"><b>❤️  Love OldWeb.today?</b></p>
+                <p style="margin: 0px">
+                Support Webrecorder via:
+                <br/><b><a href="https://opencollective.com/webrecorder" target="_blank">OpenCollective</a></b>
+                / <b><a href="https://github.com/sponsors/webrecorder" target="_blank">GitHub</a></b>
+                </p>
+              </div>
+              <p style="margin-top: 1.0rem">
+                <a href="https://github.com/oldweb-today/oldweb-today" target="_blank">View Source on GitHub</a>
               </p>
               <span>A project by:</span>
               <a href="https://webrecorder.net/" target="_blank">

--- a/src/main.js
+++ b/src/main.js
@@ -386,7 +386,10 @@ class OldWebToday extends LitElement
             </div>
             <div class="sidebar-centered-text-container" style="margin-top: 2rem;">
               <p>
-                <a href="https://github.com/oldweb-today/oldweb-today" target="_blank">How it Works / View Source</a>
+                <a href="https://github.com/oldweb-today/oldweb-today" target="_blank">OldWeb.Today on GitHub</a>
+                <br>
+                <br>
+                <a href="https://opencollective.com/webrecorder" target="_blank">Support Webrecorder on OpenCollective</a>
               </p>
               <span>A project by:</span>
               <a href="https://webrecorder.net/" target="_blank">

--- a/src/main.js
+++ b/src/main.js
@@ -402,7 +402,7 @@ class OldWebToday extends LitElement
               </a>
             </div>
           </div>
-          <div class="column" style="margin-right: 0px">
+          <div class="column" style="display:flex; justify-content: center;">
             ${this.renderEmulator()}
           </div>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -389,7 +389,7 @@ class OldWebToday extends LitElement
                 <a href="https://github.com/oldweb-today/oldweb-today" target="_blank">OldWeb.Today on GitHub</a>
                 <br>
                 <br>
-                <a href="https://opencollective.com/webrecorder" target="_blank">Support Webrecorder on OpenCollective</a>
+                <a href="https://opencollective.com/webrecorder" target="_blank">Support Webrecorder on OpenCollective ❤️</a>
               </p>
               <span>A project by:</span>
               <a href="https://webrecorder.net/" target="_blank">

--- a/src/main.js
+++ b/src/main.js
@@ -354,22 +354,14 @@ class OldWebToday extends LitElement
                 <input @change="${this.onChangeTs}" class="form-input" type="text" id="dt" ?disabled="${!this.replayTs}"
                   .value="${this.tsToDateMin(this.inputTs)}" placeholder="YYYY-MM-DD hh:mm:ss"></input>
 
-                ${!!this.replayTs ? html`
-                <details>
-                  <summary>Web Archive Sources</summary>
-                  <div>
-                  <label class="form-checkbox">
-                    <input type="checkbox" disabled checked>
-                    <i class="form-icon"></i>Internet Archive
-                    <p style="font-size: 0.75em">More options coming soon...</p>
-                  </label>
-                  </div>
-                </details>` : ``}
-
                 ${this.showTsUpdateMessage ? html`
                   <div class="msg" style="background-color: aliceblue">
                     Date Updated!<br/>Click the <i>Refresh</i> button or load a new page in the emulated browser to start browsing at the new date.
                   </div>` : html``}
+
+                  <div class="sidebar-centered-text-container">
+                    <p>Archived Webpages served from Internet Archive</p>
+                  </div>
 
                 ${this.isRunning ? html`
                   <div style="margin: 1em 0">
@@ -392,7 +384,7 @@ class OldWebToday extends LitElement
                 <button @click="${this.onDL}">Save State</button>` : ''}
               </div>
             </div>
-            <div class="by-wr">
+            <div class="sidebar-centered-text-container" style="margin-top: 2rem;">
               <p>
                 <a href="https://github.com/oldweb-today/oldweb-today" target="_blank">How it Works / View Source</a>
               </p>


### PR DESCRIPTION
### Changes
- Adds OpenCollective link
- Adds 8px rounded borders to the MacOS emulator window style
- Changes GitHub link text
- Centers the emulator window given the available space!
- Fixes title word wrapping (no more "OldWeb.Tod...ay"!)

### Screenshot

<img width="1792" alt="Screenshot 2024-06-21 at 12 06 44 AM" src="https://github.com/oldweb-today/oldweb-today/assets/5672810/12de25f2-3c3a-41a5-ae98-02431473bb95">